### PR TITLE
Fix unbuffered string error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:18-alpine
 MAINTAINER Giuseppe Mandato <gius.mand.developer@gmail.com>
 
 ENV PYTHONUNBUFFERED=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3.9"
 
 services:
   kafka-producer:
-    build: .
-    # image: hitmands/kafka-producer-stub:latest
+    # build: .
+    image: hitmands/kafka-producer-stub:latest
     environment:
       HKPS_BROKERS: "kafka:19092"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.9"
 
 services:
   kafka-producer:
-    image: hitmands/kafka-producer-stub:latest
+    build: .
+    # image: hitmands/kafka-producer-stub:latest
     environment:
       HKPS_BROKERS: "kafka:19092"
     volumes:

--- a/lib/dispatcher.mjs
+++ b/lib/dispatcher.mjs
@@ -5,6 +5,7 @@ export const createDispatcher = (clientId, producer) => ({
     { partition = null, key = null, ts = Date.now() } = {}
   ) => {
     console.log(`${clientId} / Producer.Dispatcher.Dispatch('${topic}')`);
+    console.log("message", message.toString());
 
     return producer.produce(topic, partition, message, null, ts);
   },

--- a/lib/producer.mjs
+++ b/lib/producer.mjs
@@ -23,7 +23,7 @@ export const start = async ({ clientId, messenger }) => {
       console.log(`${clientId} / Producer.Ready`);
 
       for await (const { topic, message, options } of messenger()) {
-        dispatcher.dispatch(topic, message, options);
+        dispatcher.dispatch(topic, Buffer(JSON.stringify(message)), options);
       }
 
       console.log(`${clientId} / Producer.Done`);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "faker": "^5.4.0",
-    "node-rdkafka": "^2.10.1",
+    "node-rdkafka": "^2.13.0",
     "ramda": "^0.27.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-node-rdkafka@^2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.10.1.tgz#de6055a8aed6315a68f5b401415e7d6b9bfcc631"
-  integrity sha512-yRb9Y90ipef4X+S/UbvQedUNtKZONa9RR6hCpAaGD83NqUga/uxTofdRQG8bm7SEh/DNuaifIJjRzLcoG9nUSQ==
+node-rdkafka@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.13.0.tgz#393b5db9dd40b19df8eb8b85a160402bd8046150"
+  integrity sha512-CGdURr+gapPxDT5AuWS5vyXh341vUXYQxyX5Ly3sJaSxUDnG+cE4ZCAcE6NZ79AUo7O6S3UH6c5bFRdPdTWpaw==
   dependencies:
     bindings "^1.3.1"
     nan "^2.14.0"


### PR DESCRIPTION
This repo seems really handy but I had some trouble getting it running in its default configuration, so I wanted to share what I did to get it running.

Changes:
- Upgrade to Node 18
- Fixes an issue with the producer sending unbuffered strings
- Added a log line to show the message contents

Before this change:
```
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Ready
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | /kafka-producer-stub/node_modules/node-rdkafka/lib/producer.js:139
kafka-producer_1  |     this._client.produce(topic, partition, message, key, timestamp, opaque, headers));
kafka-producer_1  |                  ^
kafka-producer_1  | 
kafka-producer_1  | Error: Message must be a buffer or null
kafka-producer_1  |     at Producer.produce (/kafka-producer-stub/node_modules/node-rdkafka/lib/producer.js:139:18)
kafka-producer_1  |     at Object.dispatch (file:///kafka-producer-stub/lib/dispatcher.mjs:9:21)
kafka-producer_1  |     at Producer.<anonymous> (file:///kafka-producer-stub/lib/producer.mjs:26:20)
kafka-producer_1  | 
kafka-producer_1  | Node.js v18.4.0
```

After this change:
```
Recreating kafka-producer-stub-orig_kafka-producer_1 ... done
Attaching to kafka-producer-stub-orig_kafka-producer_1
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.CreateInstance {
kafka-producer_1  |   'client.id': '@hitmands/kafka-producer-stub@1.0.1',
kafka-producer_1  |   'metadata.broker.list': 'kafka:19092'
kafka-producer_1  | }
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Ready
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":1,"hash":"674a59c015f8f","timestamp":1655989809364}
kafka-producer_1  | (node:1) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
kafka-producer_1  | (Use `node --trace-deprecation ...` to show where the warning was created)
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":2,"hash":"dcf2349225f55","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":3,"hash":"e5379ebd1f5c","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":4,"hash":"68662ca34734a","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":5,"hash":"afbeae45deb5d","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":6,"hash":"cc963c169dba6","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":7,"hash":"31ca9ea5c47aa","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":8,"hash":"043bebf2ce6fc","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":9,"hash":"d2df33ce5cb8c","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":10,"hash":"d919a01ffa26c","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":11,"hash":"1fa6ec28c0f45","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":12,"hash":"fffc407286de3","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":13,"hash":"412e5342e91e1","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":14,"hash":"85cdf4763f707","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":15,"hash":"23d655ce6b215","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":16,"hash":"45cabfc7a29af","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":17,"hash":"2395968b129f3","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":18,"hash":"339730ab90558","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":19,"hash":"04e72629cb1","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":20,"hash":"c68505e3ea11b","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":21,"hash":"c3125002e0259","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":22,"hash":"cc49c193bd2d1","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":23,"hash":"c1e1299d757f2","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":24,"hash":"346518739bed3","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":25,"hash":"5dcaa9509dc4e","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":26,"hash":"0fbabccc2a725","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":27,"hash":"8a9199b1c34a2","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":28,"hash":"b8137a7a703b6","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":29,"hash":"0d1a447f317db","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Dispatcher.Dispatch('stub-topic')
kafka-producer_1  | message {"id":30,"hash":"50a8efcb43169","timestamp":1655989809364}
kafka-producer_1  | @hitmands/kafka-producer-stub@1.0.1 / Producer.Done
kafka-producer-stub-orig_kafka-producer_1 exited with code 0
```